### PR TITLE
Opam: adding optional dependencies to lwt and async

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -1,4 +1,6 @@
 (library
  (name linocaml_async)
  (public_name linocaml.async)
- (libraries linocaml async async_unix))
+ (virtual_deps "async")
+ (optional)
+(libraries linocaml async async_unix))

--- a/linocaml.opam
+++ b/linocaml.opam
@@ -6,10 +6,14 @@ bug-reports: "https://github.com/keigoi/linocaml/issues"
 dev-repo: "https://github.com/keigoi/linocaml.git"
 license: "Apache"
 build:
-[[ "dune" "build" "-p" name "-j" jobs ]]
+  [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ ocaml-version >= "4.05" ]
 depends: [
   "dune" {build & >= "1.0"}
   "ocaml-migrate-parsetree"
   "ppx_tools_versioned"
+]
+depopts: [
+  "async"
+  "lwt"
 ]

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,4 +1,7 @@
 (library
  (name linocaml_lwt)
  (public_name linocaml.lwt)
- (libraries lwt lwt.unix linocaml))
+ (libraries lwt lwt.unix linocaml)
+ (virtual_deps "async")
+ (optional)
+)


### PR DESCRIPTION
Currenly, 
opam install linocaml is not working if async or lwt is not installed.
This patch fix it by making lwt and async optional dependencies and by marking related directories optional.